### PR TITLE
Fix #4 - Deployment issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,12 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.0.0"
+# gem "jekyll", "~> 4.0.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 
 baseurl: "/recommend-resources" # the subpath of your site, e.g. /blog
-url: "https://dwsmith1983.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://dwsmith1983.github.io/recommend-resources" # the base hostname & protocol for your site, e.g. http://example.com
 
 #######################################################################
 # Settings related to the Header and your About page go here,such as 

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 
 baseurl: "/recommend-resources" # the subpath of your site, e.g. /blog
-url: "https://dwsmith1983.github.io/recommend-resources/" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://dwsmith1983.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 #######################################################################
 # Settings related to the Header and your About page go here,such as 

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 
-baseurl: "/" # the subpath of your site, e.g. /blog
+baseurl: "/recommend-resources" # the subpath of your site, e.g. /blog
 url: "https://dwsmith1983.github.io/recommend-resources/" # the base hostname & protocol for your site, e.g. http://example.com
 
 #######################################################################

--- a/_includes/Feed.html
+++ b/_includes/Feed.html
@@ -45,7 +45,7 @@
 {%- if note_items.notetype == "feed" -%}
 <div class="block note-cards">
     <div class="box-feed" data-url="{{site.url}}{{note_items.url}}">
-        <a href="{{note_items.url}}" style="text-decoration: none;">
+        <a href="{{site.baseurl}}{{note_items.url}}" style="text-decoration: none;">
             <h4>{{ note_items.title }}</h4>
             <div class="content">
                 <p style="margin: 0px;">


### PR DESCRIPTION
- Changing the Gem from jekyll to gh-pages
- Modify the internal route, then the link works as expected


It works on my fork page.
https://blog.lukkiddd.com/recommend-resources

![image](https://user-images.githubusercontent.com/4519517/201980569-78e6bf96-5841-4ee4-bff9-3838f55613b8.png)


Note that the content will be rendering from `/_notes/Public` not from `/docs`
